### PR TITLE
Add dockerfile

### DIFF
--- a/.github/workflows/create_docker_image.yml
+++ b/.github/workflows/create_docker_image.yml
@@ -1,0 +1,58 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# GitHub recommends pinning actions to a commit SHA.
+# To get a newer version, you will need to update the SHA.
+# You can also reference a tag or branch, but the action may change without warning.
+
+name: Create and publish a Docker image
+
+on:
+  push:
+    paths: ['docker_context/*']
+
+  workflow_dispatch:
+    
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install editor config checker
+        run: pip install editorconfig-checker==2.0.3
+
+      - name: Check files with editor config checker
+        run: editorconfig-checker
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: ./docker_context
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/docker_context/.editorconfig
+++ b/docker_context/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+trim_trailing_whitespace = true

--- a/docker_context/Dockerfile
+++ b/docker_context/Dockerfile
@@ -1,0 +1,49 @@
+FROM ubuntu:22.04
+
+ENV LANG C.UTF-8
+
+# Work around apt-get hanging during install because it tries to query the user
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Upgrade system and install base packages
+RUN apt-get update --fix-missing\
+  && apt-get -qy upgrade \
+  && apt-get -qy install --no-install-recommends \
+    build-essential \
+    cmake  \
+    clang-format \
+    clang-tidy \
+    cppcheck \
+    graphviz \
+    # Ninja
+    ninja-build \
+    libncurses5 \
+    libc++abi-dev \
+    libc++-dev \
+    # plant uml
+	  plantuml \
+    # python pip
+	  python3-pip \
+    unzip \
+    tree \
+    wget \
+  && apt-get -qy clean \
+  && rm -rf /var/lib/apt/lists/*
+
+ARG GCC_ARM_VERSION=10.3-2021.10
+# Install GNU ARM GCC (the version from apt-get is older)
+RUN wget "https://developer.arm.com/-/media/Files/downloads/gnu-rm/$GCC_ARM_VERSION/gcc-arm-none-eabi-$GCC_ARM_VERSION-x86_64-linux.tar.bz2" --no-check-certificate \
+  && tar -xf "gcc-arm-none-eabi-$GCC_ARM_VERSION-x86_64-linux.tar.bz2" -C /opt \
+  && rm "gcc-arm-none-eabi-$GCC_ARM_VERSION-x86_64-linux.tar.bz2"
+ENV PATH="${PATH}:/opt/gcc-arm-none-eabi-$GCC_ARM_VERSION:/opt/gcc-arm-none-eabi-$GCC_ARM_VERSION/bin"
+
+# Install specific version of Doxygen (apt-get provides an older, buggy version)
+ARG DOXYGEN_VERSION=1.9.7
+RUN wget "https://www.doxygen.nl/files/doxygen-$DOXYGEN_VERSION.linux.bin.tar.gz" --no-check-certificate \
+&& tar -xf "doxygen-$DOXYGEN_VERSION.linux.bin.tar.gz" -C /opt \
+&& rm "doxygen-$DOXYGEN_VERSION.linux.bin.tar.gz"
+ENV PATH="${PATH}:/opt/doxygen-$DOXYGEN_VERSION/bin"
+
+#install required python packages
+RUN pip3 install editorconfig-checker==2.0.3 \
+  && pip3 install codespell==2.2.4


### PR DESCRIPTION
First docker docker image to build sth43 demo-board on github. This includes:
- Docker file specifies contents of docker image
- action to create image and upload the image to docker registry
- shell scripts for specific build task to be used in the build action of the firmware repository
- an editor config to make sure that the files are decently formatted